### PR TITLE
Remove deprecated function

### DIFF
--- a/lua/everybody-wants-that-line/components/diagnostics.lua
+++ b/lua/everybody-wants-that-line/components/diagnostics.lua
@@ -31,7 +31,7 @@ function M.get_diagnostics()
 	---@type diagnostics
 	local diagnostics = {}
 	local bufnr = UU.get_bufnr()
-	local is_lsp_attached = #vim.lsp.get_active_clients() > 0
+	local is_lsp_attached = #vim.lsp.get_clients() > 0
 	if is_lsp_attached then
 		diagnostics.error = get_diagnostic_object(bufnr, vim.diagnostic.severity.ERROR)
 		diagnostics.warn = get_diagnostic_object(bufnr, vim.diagnostic.severity.WARN)


### PR DESCRIPTION
get_active_clients() is deprecated in favor of get_clients() and will be removed in a future version of neovim. this also removes the annoying warning that is shown when neovim is started. :)